### PR TITLE
fix potential wrong reg_target assignment

### DIFF
--- a/projects/CenterNet2/centernet/modeling/dense_heads/centernet.py
+++ b/projects/CenterNet2/centernet/modeling/dense_heads/centernet.py
@@ -302,13 +302,13 @@ class CenterNet(nn.Module):
 
             dist2 = ((grids.view(M, 1, 2).expand(M, N, 2) - \
                 centers_expanded) ** 2).sum(dim=2) # M x N
-            dist2[is_peak] = 0
             radius2 = self.delta ** 2 * 2 * area # N
             radius2 = torch.clamp(
                 radius2, min=self.min_radius ** 2)
             weighted_dist2 = dist2 / radius2.view(1, N).expand(M, N) # M x N            
             reg_target = self._get_reg_targets(
                 reg_target, weighted_dist2.clone(), reg_mask, area) # M x 4
+            dist2[is_peak] = 0
 
             if self.only_proposal:
                 flattened_hm = self._create_agn_heatmaps_from_dist(


### PR DESCRIPTION
Fix potential wrong reg_target assignment on the center point collision problem as Objects as Points 6.1.1 said.
Though we cannot forbid the center point collision problem, we can guarantee that the reg_target assignment behavior is deterministic, assigning to the nearest one.

I'm not sure about the effect of this change, I have no enough machines to test it.
But I think this change is reasonable, especially for large epochs training.

By the way, I also wonder it is reasonable or not to remove this line `dist2[is_peak] = 0` and believe the probability totally.

Wonderful work! CenterNet2 tells us the power of probabilistic on two-stage detection.
But the CenterNet* could be further optimized, such as ground truth auto-assignment on feature pyramid instead of configuring scale range manually.