### PR TITLE
Import add_centernet_config from config.py to __init__.py

### DIFF
--- a/projects/CenterNet2/centernet/__init__.py
+++ b/projects/CenterNet2/centernet/__init__.py
@@ -14,4 +14,4 @@ from .data.datasets.coco import _PREDEFINED_SPLITS_COCO
 from .data.datasets import nuimages
 
 # Importing function from config.py
-from .config.py import add_centernet_config
+from .config import add_centernet_config

--- a/projects/CenterNet2/centernet/__init__.py
+++ b/projects/CenterNet2/centernet/__init__.py
@@ -12,3 +12,6 @@ from .modeling.backbone.res2net import build_p67_res2net_fpn_backbone
 from .data.datasets.objects365 import categories_v1
 from .data.datasets.coco import _PREDEFINED_SPLITS_COCO
 from .data.datasets import nuimages
+
+# Importing function from config.py
+from .config.py import add_centernet_config


### PR DESCRIPTION
While using CenterNet2 in Detectron2, if add_centernet_config is not imported to __init__.py, it gives - KeyError: 'Non-existent config key: MODEL.ROI_BOX_HEAD.MULT_PROPOSAL_SCORE'.

As per other projects under Detectron2 (for example - panoptic_deeplab), we can see that __init__.py imports add_panoptic_deeplab_config from its own config.py and then we call add_panoptic_deeplab_config and pass the YAML path to this function.

In the case of panoptic_deeplab,
```
from detectron2.projects import panoptic_deeplab
panoptic_deeplab.add_panoptic_deeplab_config (cfg_path)
```

Since 'add_centernet_config' was missing from centernet's __init__.py , I added it and the error was resolved.